### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ An MCP server that provides AI agents with real-time access to curated Web3 jobs
 ![Python Version](https://img.shields.io/badge/python-3.10+-blue)
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg)
 
+<a href="https://glama.ai/mcp/servers/@kukapay/web3-jobs-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/web3-jobs-mcp/badge" alt="web3-jobs-mcp MCP server" />
+</a>
 
 ## Features
 
@@ -135,4 +138,3 @@ Find Web3 jobs for a blockchain developer role in remote. Provide job titles, co
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
This PR adds a badge for the [web3-jobs-mcp](https://glama.ai/mcp/servers/@kukapay/web3-jobs-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/web3-jobs-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/web3-jobs-mcp/badge" alt="web3-jobs-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.